### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     description="CSIRTG DOMAINs ML Framework - TensorFlow",
     long_description="",
     url="https://github.com/csirtgadgets/csirtg-domainsml-tf-py",
-    license='MPLv2',
     data_files=[(os.path.join('csirtg_domainsml_tf', 'data'), data_files)],
     keywords=['network', 'security'],
     author="Wes Young",
@@ -54,4 +53,7 @@ setup(
            'csirtg-domainsml-tf=csirtg_domainsml_tf:main'
        ]
     },
+    classifiers=[
+        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)'
+    ]
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.